### PR TITLE
#67: Implemented re-try for recv

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exasol
 Type: Package
 Title: R Interface & SDK for the EXASOL Database
-Version: 5.3.0
+Version: 5.3.1
 Date: 2016-01-01
 Author: EXASOL AG & Community
 Maintainer: Marcel Boldt <marcel.boldt@exasol.com>

--- a/src/exasol.c
+++ b/src/exasol.c
@@ -336,6 +336,7 @@ static void *asyncRODBCQueryExecuter(void *arg) {
     t->res = SQLExecDirect(t->stmt, t->query, SQL_NTS);
     t->done = 1;
     if (t->res != SQL_SUCCESS && t->res != SQL_SUCCESS_WITH_INFO) {
+        fprintf(stderr, "Error executing SQLExecDirect:%d", t->res);
       shutdown(t->fd, SHUT_RDWR);
     }
     return NULL;

--- a/src/exasol.c
+++ b/src/exasol.c
@@ -101,24 +101,23 @@ static asyncODBC_t asyncODBC[MAX_RODBC_THREADS];
 
 static inline ssize_t recv_with_retry (int __fd, void *__buf, size_t __n, int __flags) {
     int rc = 0;
-    const int maxNrTrial = 1000;
+    const int maxRetries = 1000;
 #ifdef _WIN32
     rc = recv(__fd, __buf, __n, __flags);
 #else
     int idxTry = 0;
-    for (; idxTry < maxNrTrial; idxTry++) {
+    for (; idxTry < maxRetries; idxTry++) {
 
         rc = recv(__fd, __buf, __n, __flags);
 
         if (0 == rc && 0 == errno) {
-            usleep(10000); //sleep 10ms = 10000microseconds
+            usleep(10000); //sleep 1ms = 1000microseconds
         } else {
             break;
         }
     }
-    if (idxTry >= maxNrTrial) {
-        fprintf(stderr, "Reached max number of trials.\n");
-
+    if (idxTry >= maxRetries) {
+        fprintf(stderr, "Reached max number of retries.\n");
     }
 #endif
     return rc;

--- a/src/exasol.c
+++ b/src/exasol.c
@@ -101,10 +101,10 @@ static asyncODBC_t asyncODBC[MAX_RODBC_THREADS];
 
 static inline ssize_t recv_with_retry (int __fd, void *__buf, size_t __n, int __flags) {
     int rc = 0;
-    const int maxRetries = 1000;
 #ifdef _WIN32
     rc = recv(__fd, __buf, __n, __flags);
 #else
+    const int maxRetries = 1000;
     int idxTry = 0;
     for (; idxTry < maxRetries; idxTry++) {
 

--- a/src/exasol.c
+++ b/src/exasol.c
@@ -135,7 +135,6 @@ static inline ssize_t read_next_chunk(asyncODBC_t *t) {
         "Server: EXASolution R Package\r\n"
         "Connection: close\r\n\r\n";
 
-    int numTentatives = 0;
     for (pos = 0; pos < 20; pos++) {
         t->chunk_buf[pos] = t->chunk_buf[pos + 1] = '\0';
 


### PR DESCRIPTION
RCA:
On MacOS it seems that calling recv on socket can return 0, which is not necessarily an error.

Solution:
Implement a retry mechanism which tries to read 1000x from the second, and returns immediately if the return value is not 0.