### PR TITLE
#123: Fixed nightly builds

### DIFF
--- a/.github/workflows/cpp_test.yml
+++ b/.github/workflows/cpp_test.yml
@@ -1,6 +1,6 @@
 name: CI-cpp
 
-on: [push, pull_request]
+on: push
 
 jobs:
   check:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push, pull_request]
+on: push
 
 jobs:
   prep-testbed:

--- a/.github/workflows/update_docker_images.yml
+++ b/.github/workflows/update_docker_images.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build new Docker image
-        run: "bash tests/scripts/build_docker_test_env.sh ${{ matrix.r-version }}"
+        run: "bash tests/scripts/execute_docker_test_env.sh ${{ matrix.r-version }}" no_tests
       - name: Docker login
         run: echo "$SECRET_DOCKER_TOKEN" | docker login --username "$SECRET_DOCKER_USER_NAME" --password-stdin
         env: # Set the secret as an input

--- a/.github/workflows/update_docker_images.yml
+++ b/.github/workflows/update_docker_images.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build new Docker image
-        run: "bash tests/scripts/execute_docker_test_env.sh ${{ matrix.r-version }}" no_tests
+        run: bash "tests/scripts/execute_docker_test_env.sh" "${{ matrix.r-version }}" no_tests
       - name: Docker login
         run: echo "$SECRET_DOCKER_TOKEN" | docker login --username "$SECRET_DOCKER_USER_NAME" --password-stdin
         env: # Set the secret as an input

--- a/.github/workflows/windows_macosx.yml
+++ b/.github/workflows/windows_macosx.yml
@@ -1,6 +1,9 @@
 name: CI-BuildOnly
 
-on: [push, pull_request]
+on:
+  - push
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
   build:

--- a/.github/workflows/windows_macosx.yml
+++ b/.github/workflows/windows_macosx.yml
@@ -1,7 +1,7 @@
 name: CI-BuildOnly
 
 on:
-  - push
+  push:
   schedule:
     - cron: '0 0 * * *'
 

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ src/*.dll
 config.log
 config.status
 /tests/cpp/cmake-build-debug/
+.idea

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ The package gets tested in Github against R 3.5, 3.6, 4.0 and 4.1, but it also w
 - https://github.com/marcelboldt/DBI
 - https://github.com/marcelboldt/DBItest
 
+For Windows only: As this package uses C++14 code, it needs at least RTools >= 4.0.0. Hence, it works only on R >= 4.0.0.
+
 The low-level methods such as regards `exa.readData`, `exa.writeData` and `exa.createScript` may work as expected, so
 should the DBI connection methods (`dbConnect`, etc.; all tests passed). DBI querying methods also get close to being production ready.
 
@@ -44,7 +46,7 @@ ODBC drivers 7.1.1 & 7.1.2 under MacOsX BigSur have a dependency issue. If you h
 
 1. Install developer extensions for R to be able to build from sources
 
-   For Windows: Install `Rtools` matching your version of R from [here](https://cran.r-project.org/bin/windows/Rtools/).
+   For Windows: Install `Rtools` matching your version of R from [here](https://cran.r-project.org/bin/windows/Rtools/), but at least version 4.0.0.
    
    For Linux: Install the `R-base-devel` (RPM) or `r-base-dev` (Debian) package.
    

--- a/doc/changes/changes_7.1.0.md
+++ b/doc/changes/changes_7.1.0.md
@@ -17,6 +17,7 @@ t.b.d.
  - #93: Fixed cloned connection
  - #91: Fixed issue with encoding passwords correctly
  - #125: Fixed linker error on windows with R4.2
+ - #123: Fixed nightly builds
 
 ## Documentation
 

--- a/tests/run_test_within_docker.sh
+++ b/tests/run_test_within_docker.sh
@@ -32,6 +32,8 @@ if [ $# -gt 1 ]; then
       export ASAN_OPTIONS=detect_leaks=0 #disable leak detection because R itself has memory leaks. It would break
       export LD_PRELOAD=/usr/lib/gcc/x86_64-linux-gnu/7/libasan.so
     ;;
+    no_tests)
+      TST_CMD="echo Skipping tests..."
   esac
 fi
 


### PR DESCRIPTION
1. Until now we only compiled the R dependencies during the nightly test. No we also compile r-exasol itself, (but not as part of the docker image)
2. Also compile on Windows/MacOsX every night in order to validate new versions of R
3. Added more information regarding minimum version o R/RTools on Windows

fixes #123 