### PR TITLE
#125 fixed linker error with r42

### DIFF
--- a/.github/workflows/windows_macosx.yml
+++ b/.github/workflows/windows_macosx.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Show include folder of RTools
         if: matrix.config.os == 'windows-latest'
         run: |
-          tree c:\rtools42\x86_64-w64-mingw32.static.posix\include /f
+          tree c:/rtools42/x86_64-w64-mingw32.static.posix/include /f
       - name: Install openssl MacOsX
         if: matrix.config.os == 'macOS-latest'
         run: |

--- a/.github/workflows/windows_macosx.yml
+++ b/.github/workflows/windows_macosx.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Show include folder of RTools
         if: matrix.config.os == 'windows-latest'
         run: tree "c:\rtools42\x86_64-w64-mingw32.static.posix\include" /f
-      - name Show content of openssl
+      - name: Show content of openssl
         if: matrix.config.os == 'windows-latest'
         run: Rscript.exe -e "list.files(\"c:\\\\rtools42\\\\x86_64-w64-mingw32.static.posix\\\\include\\\\openssl\")"
       - name: Install openssl MacOsX

--- a/.github/workflows/windows_macosx.yml
+++ b/.github/workflows/windows_macosx.yml
@@ -20,6 +20,10 @@ jobs:
         with:
           r-version: ${{ matrix.config.r }}
 
+      - name: Show include folder of RTools
+        if: matrix.config.os == 'windows-latest'
+        run: |
+          tree c:\rtools42\x86_64-w64-mingw32.static.posix\include /f
       - name: Install openssl MacOsX
         if: matrix.config.os == 'macOS-latest'
         run: |

--- a/.github/workflows/windows_macosx.yml
+++ b/.github/workflows/windows_macosx.yml
@@ -21,12 +21,6 @@ jobs:
           r-version: ${{ matrix.config.r }}
           rtools-version: ${{ matrix.config.r_tools }}
 
-      - name: Show dir of C:\
-        if: matrix.config.os == 'windows-latest'
-        run: dir c:\
-      - name: Show include folder of RTools
-        if: matrix.config.os == 'windows-latest'
-        run: tree "c:\rtools42\x86_64-w64-mingw32.static.posix\include" /f
       - name: Install openssl MacOsX
         if: matrix.config.os == 'macOS-latest'
         run: |

--- a/.github/workflows/windows_macosx.yml
+++ b/.github/workflows/windows_macosx.yml
@@ -10,8 +10,8 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { os: windows-latest, r: 'release' }
-          - { os: macOS-latest, r: 'release' }
+          - { os: windows-latest, r: 'release' , r_tools: "42"}
+          - { os: macOS-latest, r: 'release' , r_tools: "42"}
     environment: ci_build
     steps:
       - uses: actions/checkout@v2
@@ -19,13 +19,14 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
+          rtools-version: ${{ matrix.config.r_tools }}
 
+      - name: Show dir of C:\
+        if: matrix.config.os == 'windows-latest'
+        run: dir c:\
       - name: Show include folder of RTools
         if: matrix.config.os == 'windows-latest'
         run: tree "c:\rtools42\x86_64-w64-mingw32.static.posix\include" /f
-      - name: Show content of openssl
-        if: matrix.config.os == 'windows-latest'
-        run: Rscript.exe -e "list.files(\"c:\\\\rtools42\\\\x86_64-w64-mingw32.static.posix\\\\include\\\\openssl\")"
       - name: Install openssl MacOsX
         if: matrix.config.os == 'macOS-latest'
         run: |

--- a/.github/workflows/windows_macosx.yml
+++ b/.github/workflows/windows_macosx.yml
@@ -12,6 +12,8 @@ jobs:
         config:
           - { os: windows-latest, r: 'release' , r_tools: "42"}
           - { os: macOS-latest, r: 'release' , r_tools: "42"}
+          - { os: windows-latest, r: '4.1.0' , r_tools: "40"}
+          - { os: macOS-latest, r: '4.1.0' , r_tools: "40"}
     environment: ci_build
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/windows_macosx.yml
+++ b/.github/workflows/windows_macosx.yml
@@ -24,6 +24,7 @@ jobs:
         if: matrix.config.os == 'windows-latest'
         run: |
           tree "c:\rtools42\x86_64-w64-mingw32.static.posix\include" /f
+        shell: cmd
       - name: Install openssl MacOsX
         if: matrix.config.os == 'macOS-latest'
         run: |

--- a/.github/workflows/windows_macosx.yml
+++ b/.github/workflows/windows_macosx.yml
@@ -22,9 +22,10 @@ jobs:
 
       - name: Show include folder of RTools
         if: matrix.config.os == 'windows-latest'
-        run: |
-          tree "c:\rtools42\x86_64-w64-mingw32.static.posix\include" /f
-        shell: cmd
+        run: tree "c:\rtools42\x86_64-w64-mingw32.static.posix\include" /f
+      - name Show content of openssl
+        if: matrix.config.os == 'windows-latest'
+        run: Rscript.exe -e "list.files(\"c:\\\\rtools42\\\\x86_64-w64-mingw32.static.posix\\\\include\\\\openssl\")"
       - name: Install openssl MacOsX
         if: matrix.config.os == 'macOS-latest'
         run: |

--- a/.github/workflows/windows_macosx.yml
+++ b/.github/workflows/windows_macosx.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Show include folder of RTools
         if: matrix.config.os == 'windows-latest'
         run: |
-          tree c:/rtools42/x86_64-w64-mingw32.static.posix/include /f
+          tree "c:\rtools42\x86_64-w64-mingw32.static.posix\include" /f
       - name: Install openssl MacOsX
         if: matrix.config.os == 'macOS-latest'
         run: |

--- a/doc/changes/changes_7.1.0.md
+++ b/doc/changes/changes_7.1.0.md
@@ -15,8 +15,8 @@ t.b.d.
  - #115: Added job-names to GH Workflows
  - #106: Fixed installation issue with OpenSSL already installed message
  - #93: Fixed cloned connection
-
-- #91: Fixed issue with encoding passwords correctly
+ - #91: Fixed issue with encoding passwords correctly
+ - #125: Fixed linker error on windows with R4.2
 
 ## Documentation
 

--- a/src/Makevars.ucrt
+++ b/src/Makevars.ucrt
@@ -1,21 +1,15 @@
-#Makevars for windows and RTools <= 4.0.0
-OPENSSL_VERSION=1.1.1k
-PKG_LIBS=-lodbc32 -lpthread -lws2_32 -L../windows/openssl-$(OPENSSL_VERSION)/lib${R_ARCH}${CRT} -lssl -lcrypto -lws2_32 -lcrypt32
-PKG_CPPFLAGS =  -I. -I../windows/openssl-$(OPENSSL_VERSION)/include
+#Makevars for windows and RTools >= 4.2.0
+PKG_LIBS=-lodbc32 -lpthread -lws2_32 -lssl -lcrypto -lws2_32 -lcrypt32 -lz
+PKG_CPPFLAGS =  -I.
 SOURCES = r_exasol/connection_context.cpp r_exasol/rconnection/r_reader_connection.cpp r_exasol/rconnection/r_writer_connection.cpp r_exasol/ssl/certificate.cpp r_exasol/connection/socket/socket_impl.cpp r_exasol/connection/socket/ssl_socket_impl.cpp r_exasol/connection/protocol/meta_info_reader.cpp r_exasol/connection/protocol/common.cpp r_exasol/connection/protocol/http/writer/http_chunk_writer.cpp r_exasol/connection/protocol/http/reader/http_chunk_reader.cpp r_exasol/connection/protocol/http/conn/http_connection_establisher.cpp r_exasol/connection/protocol/https/conn/https_connection_establisher.cpp r_exasol/connection/connection_controller.cpp r_exasol/connection/connection_factory_impl.cpp r_exasol/odbc/odbc_query_executor.cpp r_exasol/odbc/odbc_session_info_impl.cpp connection.cpp r_exasol/debug_print/debug_printer.cpp r_exasol/debug_print/file_logger.cpp tests/test_runner.cpp
 CXX_STD = CXX14
 OBJECTS = r_exasol/connection_context.o r_exasol/rconnection/r_reader_connection.o r_exasol/rconnection/r_writer_connection.o r_exasol/ssl/certificate.o r_exasol/connection/socket/socket_impl.o r_exasol/connection/socket/ssl_socket_impl.o r_exasol/connection/protocol/meta_info_reader.o r_exasol/connection/protocol/common.o r_exasol/connection/protocol/http/writer/http_chunk_writer.o r_exasol/connection/protocol/http/reader/http_chunk_reader.o r_exasol/connection/protocol/http/conn/http_connection_establisher.o r_exasol/connection/protocol/https/conn/https_connection_establisher.o r_exasol/connection/connection_controller.o r_exasol/connection/connection_factory_impl.o r_exasol/odbc/odbc_query_executor.o r_exasol/odbc/odbc_session_info_impl.o connection.o r_exasol/debug_print/debug_printer.o r_exasol/debug_print/file_logger.o tests/test_runner.o
 OBJECTS += exasol.o
 
-.PHONY: all winlibs
+.PHONY: all
 
 all: $(SHLIB)
-
-$(OBJECTS): winlibs
 
 all: $(OBJECTS)
 clean:
 	rm -f  $(SHLIB) $(OBJECTS)
-
-winlibs:
-	"${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" "../tools/winlibs.R" $(OPENSSL_VERSION)


### PR DESCRIPTION
fixes #125 

### RCA
The openssl library which is downloaded during build time is not compatible anymore with RTools 4.2.
See https://cran.r-project.org/bin/windows/base/howto-R-4.2.html => "Linking to pre-built static libraries" for details.

### Solution
1. RTools4.2 now ships with its own version of openssl (That is good!!!)
2. As the documentation proposes, create an new file Makevars.ucrt, which will be used on Windows and RTools > 4.2.
3. The GH-Actions (r-lib/actions/setup-r@v2) is not smart enough to set the correct RTools version automatically. We must set it hard-coded to 4.2